### PR TITLE
feat: 비로그인 시 특정 라우터 접근 제한 기능 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ConfigModule, ConfigService } from '@nestjs/config';
@@ -19,6 +19,7 @@ import { AuthModule } from './auth/auth.module';
 import { ProjectsModule } from './projects/projects.module';
 import { ClientsModule } from './clients/clients.module';
 import { ParticipationsModule } from './participations/participations.module';
+import { AuthMiddleware } from './auth.middleware';
 
 @Module({
   imports: [
@@ -48,4 +49,8 @@ import { ParticipationsModule } from './participations/participations.module';
   controllers: [AppController],
   providers: [AppService, ConfigService],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(AuthMiddleware).forRoutes('*');
+  }
+}

--- a/src/auth.middleware.spec.ts
+++ b/src/auth.middleware.spec.ts
@@ -1,0 +1,7 @@
+import { AuthMiddleware } from './auth.middleware';
+
+describe('AuthMiddleware', () => {
+  it('should be defined', () => {
+    expect(new AuthMiddleware()).toBeDefined();
+  });
+});

--- a/src/auth.middleware.ts
+++ b/src/auth.middleware.ts
@@ -1,0 +1,23 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { NextFunction, Response } from 'express';
+
+@Injectable()
+export class AuthMiddleware implements NestMiddleware {
+  use(req: any, res: Response, next: NextFunction) {
+    // 로그인 권한이 필요한 라우터 리스트
+    const includes = ['staffs', 'staff', 'project'];
+
+    const path: string = req._parsedUrl.pathname;
+
+    if (!includes.includes(path.split('/')[1])) {
+      return next();
+    }
+
+    if (req.user === undefined) {
+      console.log(`NOT LOGINED: ${req.originalUrl}`);
+      return res.redirect('/login');
+    }
+
+    next();
+  }
+}


### PR DESCRIPTION
- `AuthMiddleware` 미들웨어 추가
  - 로그인 권한이 필요한 라우터에 대해 비로그인 상태에서 접근할 경우 로그인 페이지로 이동하도록 설정
  - 접근 제한 라우터는 Blacklist 방식으로 관리됨. (`auth.middleware.ts`의 `includes` 변수 참고)